### PR TITLE
synchronize increments of nbItemsets to avoid race condition

### DIFF
--- a/src/plcm.cpp
+++ b/src/plcm.cpp
@@ -136,7 +136,6 @@ void lcmIter(const TransactionTable &tt, OccurencesTable *ot,
   }
   
   dumpItemset(*itemset, freq); 
-  nbItemsets++; 
 
   item_t maxCandidate = -1;
   int nbCandidates = 0; 
@@ -301,6 +300,8 @@ void dumpItemset(const Itemset &itemset, freq_t freq){
   }
   *output<<"("<<freq<<")\n";
   
+  nbItemsets++;
+
   pthread_mutex_unlock(&mutex); 
 
 }


### PR DESCRIPTION
plcm sometimes report different number of frequent itemsets. e.g.

```
bash-3.2$ src/plcm  -t 4 T40I10D100K.dat.txt 1000 out.txt
src/plcm  -t 4 T40I10D100K.dat.txt 1000 out.txt
NDEBUG is defined.
PARALLEL_PROCESS is defined.
REBASE_PERMUTE_ITEMS is NOT defined.
DB_REDUCTION_REDUCE_INITIAL_DB is defined.
MULTI_LEVEL_TUPLES is defined.
Pushing 755 tuples
Creating 4 thread(s).
TIME 2.20357s.
Number of itemset(s): 65236.
```

```
bash-3.2$ src/plcm  -t 4 T40I10D100K.dat.txt 1000 out.txt
src/plcm  -t 4 T40I10D100K.dat.txt 1000 out.txt
NDEBUG is defined.
PARALLEL_PROCESS is defined.
REBASE_PERMUTE_ITEMS is NOT defined.
DB_REDUCTION_REDUCE_INITIAL_DB is defined.
MULTI_LEVEL_TUPLES is defined.
Pushing 755 tuples
Creating 4 thread(s).
TIME 2.10516s.
Number of itemset(s): 65234.
```

I think it is because `nbItemsets++;` is not synchronized.

This PR fixes the problem.